### PR TITLE
Add inference engine boilerplate & testsuite

### DIFF
--- a/dev/generate_test_trajectory.ts
+++ b/dev/generate_test_trajectory.ts
@@ -1,0 +1,144 @@
+const USAGE = `ts-node --dir dev generate_test_trajectory.ts <gpx-file-home> <gpx-file-home-to-work> <gpx-file-work> <gpx-file-work-to-home>`
+
+import * as fs from 'fs'
+import * as GPX from 'gpx-parse'
+import * as path from 'path'
+import { Trajectory, TrajectoryType } from '../src/app/model/trajectory'
+
+function argparse() {
+  const args = process.argv.slice(2)
+  if (args.length !== 4) {
+    console.error(`usage: ${USAGE}`)
+    process.exit(1)
+  }
+  const [
+    filepath_home,
+    filepath_home_to_work,
+    filepath_work,
+    filepath_work_to_home,
+  ] = args
+  return {
+    filepath_home,
+    filepath_home_to_work,
+    filepath_work,
+    filepath_work_to_home,
+  }
+}
+
+type Parser = (
+  id: string,
+  placename: string,
+  data: string
+) => Promise<Trajectory>
+
+function getParser(input: string): Parser {
+  return (id, placename, input) => {
+    return new Promise((resolve, reject) => {
+      GPX.parseGpx(input, (err, parsed) => {
+        if (err) return reject(err)
+        const coordinates = []
+        const timestamps = []
+        for (const track of parsed.tracks) {
+          for (const waypoints of track.segments) {
+            for (const { lat, lon, time } of waypoints) {
+              coordinates.push([lat, lon])
+              timestamps.push(time)
+            }
+          }
+        }
+        const meta = { id, placename, type: TrajectoryType.EXAMPLE }
+        const data = { coordinates, timestamps }
+        resolve(new Trajectory(meta, data))
+      })
+    })
+  }
+}
+
+function createCluster(
+  trajectory: Trajectory,
+  numberPoints: number = 30,
+  radius: number = 15
+): Trajectory {
+  const seed = trajectory.coordinates[trajectory.coordinates.length - 1]
+  for (var i: number = 0; i < numberPoints; i++) {
+    const rand = randomGeo(seed[0], seed[1], radius)
+    trajectory.coordinates.push([rand.latitude, rand.longitude])
+    trajectory.timestamps.push(null)
+  }
+  return trajectory
+}
+
+function randomGeo(
+  latitude: number,
+  longitude: number,
+  radiusInMeters: number
+) {
+  var y0 = latitude
+  var x0 = longitude
+  var rd = radiusInMeters / 111300
+
+  var u = Math.random()
+  var v = Math.random()
+
+  var w = rd * Math.sqrt(u)
+  var t = 2 * Math.PI * v
+  var x = w * Math.cos(t)
+  var y = w * Math.sin(t)
+
+  return {
+    latitude: y + y0,
+    longitude: x + x0,
+  }
+}
+
+function exportToCsv(trajectories: Trajectory[]) {
+  let csvContent = 'latitude,longitude,timestamp\n'
+  trajectories.forEach((trajectory) => {
+    csvContent += trajectory.coordinates
+      .map((c, i) => {
+        return [c[0], c[1], trajectory.timestamps[i]].join(',')
+      })
+      .join('\n')
+    csvContent += '\n'
+  })
+  fs.writeFile('trajectory.csv', csvContent, function (error) {
+    if (error) return console.log(error)
+  })
+}
+
+function loadTrajectoryFromGpxFile(filepath: string): Promise<Trajectory> {
+  const ext = path.extname(filepath)
+  if (ext != '.gpx') throw new Error('unsupported format: gpx expected')
+
+  const id = path.basename(filepath, ext)
+  const content = fs.readFileSync(filepath, { encoding: 'utf-8' })
+  const parser = getParser(ext)
+  return parser(id, id, content)
+}
+
+async function main() {
+  const {
+    filepath_home,
+    filepath_home_to_work,
+    filepath_work,
+    filepath_work_to_home,
+  } = argparse()
+  let trajectory_home = await loadTrajectoryFromGpxFile(filepath_home)
+  let trajectory_home_to_work = await loadTrajectoryFromGpxFile(
+    filepath_home_to_work
+  )
+  let trajectory_work = await loadTrajectoryFromGpxFile(filepath_work)
+  let trajectory_work_to_home = await loadTrajectoryFromGpxFile(
+    filepath_work_to_home
+  )
+  trajectory_home = createCluster(trajectory_home)
+  trajectory_work = createCluster(trajectory_work)
+  exportToCsv([
+    trajectory_home,
+    trajectory_home_to_work,
+    trajectory_work_to_home,
+    trajectory_work,
+  ])
+}
+
+main().catch((err) => console.error(err))

--- a/package-lock.json
+++ b/package-lock.json
@@ -2195,6 +2195,31 @@
         }
       }
     },
+    "@turf/distance": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.3.0.tgz",
+      "integrity": "sha512-basi24ssNFnH3iXPFjp/aNUrukjObiFWoIyDRqKyBJxVwVOwAWvfk4d38QQyBj5nDo5IahYRq/Q+T47/5hSs9w==",
+      "dev": true,
+      "requires": {
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
+      }
+    },
+    "@turf/helpers": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
+      "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg==",
+      "dev": true
+    },
+    "@turf/invariant": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.3.0.tgz",
+      "integrity": "sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==",
+      "dev": true,
+      "requires": {
+        "@turf/helpers": "^6.3.0"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "ng serve",
     "build": "ng build",
     "test": "ng test",
+    "test:inferences": "ng test --include src/app/shared-services/inferences/",
     "lint": "prettier --loglevel=warn --write src/app && tslint -p . \"src/app/**/*.ts\"",
     "e2e": "ng e2e",
     "postinstall": "jetifier"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@angular/language-service": "~10.0.0",
     "@capacitor/cli": "2.4.0",
     "@ionic/angular-toolkit": "^2.3.0",
+    "@turf/distance": "^6.3.0",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/leaflet": "^1.5.17",

--- a/src/app/model/inference.ts
+++ b/src/app/model/inference.ts
@@ -1,4 +1,4 @@
-class Inference {
+export class Inference {
   constructor(
     public name: string,
     public description: string,

--- a/src/app/model/inference.ts
+++ b/src/app/model/inference.ts
@@ -3,7 +3,7 @@ export class Inference {
     public name: string,
     public description: string,
     public trajectoryId: string,
-    public location: [number, number],
+    public lonLat: [number, number],
     public confidence?: number,
     public accuracy?: number
   ) {}

--- a/src/app/model/inference.ts
+++ b/src/app/model/inference.ts
@@ -3,7 +3,8 @@ class Inference {
     public name: string,
     public description: string,
     public trajectoryId: string,
-    public location?: [number, number],
+    public location: [number, number],
+    public confidence?: number,
     public accuracy?: number
   ) {}
 }

--- a/src/app/shared-services/inferences/definitions.ts
+++ b/src/app/shared-services/inferences/definitions.ts
@@ -1,0 +1,23 @@
+import { Point } from 'src/app/model/trajectory'
+import { InferenceDefinition, InferenceResult } from './types'
+
+export const WorkInference = new InferenceDefinition(
+  'workplace',
+  (lang?: string) => 'Workplace',
+  (r: InferenceResult, lang?: string) =>
+    `We assume your workplace is at ${r.location} with a confidence of ${r.confidence}.`,
+  [(p: Point) => 0] // TODO
+)
+
+export const HomeInference = new InferenceDefinition(
+  'home',
+  (lang?: string) => 'Home',
+  (r: InferenceResult, lang?: string) =>
+    `We assume your home is at ${r.location} with a confidence of ${r.confidence}.`,
+  [(p: Point) => 1] // TODO
+)
+
+export const AllInferences = {
+  [HomeInference.id]: HomeInference,
+  [WorkInference.id]: WorkInference,
+}

--- a/src/app/shared-services/inferences/definitions.ts
+++ b/src/app/shared-services/inferences/definitions.ts
@@ -5,7 +5,7 @@ export const WorkInference = new InferenceDefinition(
   'workplace',
   (lang?: string) => 'Workplace',
   (r: InferenceResult, lang?: string) =>
-    `We assume your workplace is at ${r.location} with a confidence of ${r.confidence}.`,
+    `We assume your workplace is at ${r.lonLat} with a confidence of ${r.confidence}.`,
   [(p: Point) => 0] // TODO
 )
 
@@ -13,7 +13,7 @@ export const HomeInference = new InferenceDefinition(
   'home',
   (lang?: string) => 'Home',
   (r: InferenceResult, lang?: string) =>
-    `We assume your home is at ${r.location} with a confidence of ${r.confidence}.`,
+    `We assume your home is at ${r.lonLat} with a confidence of ${r.confidence}.`,
   [(p: Point) => 1] // TODO
 )
 

--- a/src/app/shared-services/inferences/simple-engine.spec.fixtures.ts
+++ b/src/app/shared-services/inferences/simple-engine.spec.fixtures.ts
@@ -1,0 +1,35 @@
+import { TrajectoryData } from 'src/app/model/trajectory'
+
+export const trajEmpty: TrajectoryData = {
+  coordinates: [],
+  timestamps: [],
+  accuracy: [],
+}
+
+// TODO
+export const trajMobileOnly: TrajectoryData = {
+  coordinates: [],
+  timestamps: [],
+  accuracy: [],
+}
+
+// TODO
+export const trajHomeWork: TrajectoryData = {
+  coordinates: [],
+  timestamps: [],
+  accuracy: [],
+}
+
+// TODO
+export const trajHomeWorkSpatiallyDense: TrajectoryData = {
+  coordinates: [],
+  timestamps: [],
+  accuracy: [],
+}
+
+// TODO
+export const trajHomeWorkTemporallySparse: TrajectoryData = {
+  coordinates: [],
+  timestamps: [],
+  accuracy: [],
+}

--- a/src/app/shared-services/inferences/simple-engine.spec.ts
+++ b/src/app/shared-services/inferences/simple-engine.spec.ts
@@ -1,7 +1,8 @@
 import { async } from '@angular/core/testing'
 import { LatLngTuple } from 'leaflet'
 import { Inference } from 'src/app/model/inference'
-import { TrajectoryData } from 'src/app/model/trajectory'
+import { Trajectory, TrajectoryData } from 'src/app/model/trajectory'
+import nepal from 'src/assets/trajectories/3384596.json'
 import { AllInferences, HomeInference } from './definitions'
 import { SimpleEngine } from './simple-engine'
 import { trajEmpty, trajMobileOnly } from './simple-engine.spec.fixtures'
@@ -25,7 +26,9 @@ describe('inferences/SimpleEngine', () => {
       t.test(new SimpleEngine())
     })
 
-    it('should infer with low confidence for low point count', () => {}) // TODO
+    it('should infer with low confidence for low stationary point count', () => {}) // TODO
+
+    it('should infer with low confidence for low total point count', () => {}) // TODO
 
     it('should not infer for mobile only trajectory', () => {
       const t = new InferenceTestCase(trajMobileOnly, [HomeInference], [])
@@ -33,9 +36,22 @@ describe('inferences/SimpleEngine', () => {
     })
 
     it('should infer for single night location', () => {}) // TODO
-    it('should infer with low confidence for single 2 different night locations', () => {}) // TODO
+
+    it('should infer with low confidence for 2 different night locations', () => {}) // TODO
+
     it('should infer for realworld data (1 day)', () => {}) // TODO
-    it('should infer for realworld data (1 month)', () => {}) // TODO: nepal dataset?
+
+    it('should infer for realworld data (1 month)', () => {
+      // NOTE: nepal trajectory seems to be partially everyday-life, partially dedicated OSM-mapping activities
+      expect(nepal).toBeDefined('nepal fixture not loaded')
+      const t = new InferenceTestCase(
+        Trajectory.fromJSON(nepal),
+        [HomeInference],
+        [] // TODO
+      )
+      t.test(new SimpleEngine())
+    })
+
     it('should infer for realworld data (1 year)', () => {}) // TODO: find data
 
     // TODO: test temporally, spatially sparse trajectories

--- a/src/app/shared-services/inferences/simple-engine.spec.ts
+++ b/src/app/shared-services/inferences/simple-engine.spec.ts
@@ -1,5 +1,11 @@
 import { async } from '@angular/core/testing'
+import { LatLngTuple } from 'leaflet'
+import { Inference } from 'src/app/model/inference'
+import { TrajectoryData } from 'src/app/model/trajectory'
+import { AllInferences, HomeInference } from './definitions'
 import { SimpleEngine } from './simple-engine'
+import { trajEmpty, trajMobileOnly } from './simple-engine.spec.fixtures'
+import { IInferenceEngine, InferenceDefinition } from './types'
 
 describe('inferences/SimpleEngine', () => {
   beforeEach(async(() => {}))
@@ -8,4 +14,79 @@ describe('inferences/SimpleEngine', () => {
     const e = new SimpleEngine()
     expect(e).toBeTruthy()
   })
+
+  describe('HomeInference', () => {
+    it('should not infer for 0 points', () => {
+      const t = new InferenceTestCase(
+        trajEmpty,
+        Object.values(AllInferences),
+        []
+      )
+      t.test(new SimpleEngine())
+    })
+
+    it('should infer with low confidence for low point count', () => {}) // TODO
+
+    it('should not infer for mobile only trajectory', () => {
+      const t = new InferenceTestCase(trajMobileOnly, [HomeInference], [])
+      t.test(new SimpleEngine())
+    })
+
+    it('should infer for single night location', () => {}) // TODO
+    it('should infer with low confidence for single 2 different night locations', () => {}) // TODO
+    it('should infer for realworld data (1 day)', () => {}) // TODO
+    it('should infer for realworld data (1 month)', () => {}) // TODO: nepal dataset?
+    it('should infer for realworld data (1 year)', () => {}) // TODO: find data
+
+    // TODO: test temporally, spatially sparse trajectories
+  })
+
+  describe('WorkInference', () => {
+    // TODO: migrate from HomeInference, once done
+  })
 })
+
+class InferenceTestCase {
+  constructor(
+    public trajectory: TrajectoryData,
+    public inferences: InferenceDefinition[],
+    public results: InferenceResultTest[],
+    public deltaMeters: number = 50
+  ) {}
+
+  test(e: IInferenceEngine): Inference[] {
+    const results = e.infer(this.trajectory, this.inferences)
+
+    // inference count
+    expect(results.length).toEqual(
+      Object.keys(this.results).length,
+      'wrong inferences'
+    )
+
+    for (const res of this.results) {
+      const hasID = results.some((r) => r.name === res.name)
+      expect(hasID).toEqual(true, `'${res.name}' expected, but not inferred`)
+    }
+
+    for (const r of results) {
+      // inference type matches
+      expect(this.results[r.name]).toBeDefined(
+        `'${r.name}' inferred, but not expected`
+      )
+
+      // inference location
+      const deltaMeters = 0.0 // TODO turf.distance()
+      expect(deltaMeters).toBeLessThanOrEqual(
+        this.deltaMeters,
+        `'${r.name}' location didn't match`
+      )
+    }
+
+    return results
+  }
+}
+
+type InferenceResultTest = {
+  name: string
+  location: LatLngTuple
+}

--- a/src/app/shared-services/inferences/simple-engine.spec.ts
+++ b/src/app/shared-services/inferences/simple-engine.spec.ts
@@ -1,0 +1,11 @@
+import { async } from '@angular/core/testing'
+import { SimpleEngine } from './simple-engine'
+
+describe('inferences/SimpleEngine', () => {
+  beforeEach(async(() => {}))
+
+  it('should create', () => {
+    const e = new SimpleEngine()
+    expect(e).toBeTruthy()
+  })
+})

--- a/src/app/shared-services/inferences/simple-engine.spec.ts
+++ b/src/app/shared-services/inferences/simple-engine.spec.ts
@@ -93,7 +93,7 @@ class InferenceTestCase {
 
       // inference location
       const expectedLonLat = [expectation.location[1], expectation.location[0]]
-      const inferredLonLat = [r.location[1], r.location[0]]
+      const inferredLonLat = [r.lonLat[1], r.lonLat[0]]
       const dist = distance(expectedLonLat, inferredLonLat, {
         units: 'kilometers',
       })

--- a/src/app/shared-services/inferences/simple-engine.ts
+++ b/src/app/shared-services/inferences/simple-engine.ts
@@ -1,0 +1,12 @@
+import { TrajectoryData } from 'src/app/model/trajectory'
+import { IInferenceEngine, InferenceDefinition, InferenceResult } from './types'
+
+export class SimpleEngine implements IInferenceEngine {
+  infer(
+    t: TrajectoryData,
+    inferences: InferenceDefinition[]
+  ): InferenceResult[] {
+    // TODO
+    return []
+  }
+}

--- a/src/app/shared-services/inferences/types.ts
+++ b/src/app/shared-services/inferences/types.ts
@@ -1,0 +1,21 @@
+import { Point, TrajectoryData } from 'src/app/model/trajectory'
+
+export interface IInferenceEngine {
+  infer(
+    trajectory: TrajectoryData,
+    inferences: InferenceDefinition[]
+  ): InferenceResult[]
+}
+
+export class InferenceDefinition {
+  constructor(
+    public id: string,
+    public name: (lang?: string) => string,
+    public info: (res: InferenceResult, lang?: string) => string,
+    public scoringFuncs: ScoringFunc[]
+  ) {}
+}
+
+export type ScoringFunc = (p: Point) => number
+
+export type InferenceResult = Inference

--- a/src/app/shared-services/inferences/types.ts
+++ b/src/app/shared-services/inferences/types.ts
@@ -1,3 +1,4 @@
+import { Inference } from 'src/app/model/inference'
 import { Point, TrajectoryData } from 'src/app/model/trajectory'
 
 export interface IInferenceEngine {

--- a/src/app/shared-services/trajectory.service.ts
+++ b/src/app/shared-services/trajectory.service.ts
@@ -1,6 +1,5 @@
 import { HttpClient } from '@angular/common/http'
 import { Injectable } from '@angular/core'
-import * as polyline from '@mapbox/polyline'
 import { combineLatest, from, Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 import {
@@ -60,21 +59,7 @@ export class TrajectoryService {
           .get<{ coordinates: string; timestamps: number[]; time0: string }>(
             `assets/trajectories/${id}.json`
           )
-          .pipe(
-            map(({ coordinates, timestamps, time0 }) => ({
-              coordinates: polyline.decode(coordinates) as [number, number][],
-              timestamps: timestamps.reduce<Date[]>((ts, t, i, deltas) => {
-                // The array from the JSON has one element less than locations,
-                // as it contains time deltas. To restore absolute dates, we add
-                // the first timestamp & in the same iteration also add the first delta
-                if (i === 0) ts.push(new Date(time0))
-                const t1 = ts[i]
-                const deltaMs = deltas[i] * 1000
-                ts.push(new Date(t1.getTime() + deltaMs))
-                return ts
-              }, []),
-            }))
-          )
+          .pipe(map(Trajectory.fromJSON))
 
         const getMeta = this.http
           .get<TrajectoryMeta[]>('assets/trajectories/index.json')

--- a/src/app/trajectory/inferences/inference.service.ts
+++ b/src/app/trajectory/inferences/inference.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core'
+import { Inference } from 'src/app/model/inference'
 
 @Injectable({
   providedIn: 'root',
@@ -15,6 +16,7 @@ export class InferenceService {
     {
       name: 'Workplace',
       description: 'We know where you work.',
+      location: [51.968446, 7.61249],
       trajectoryId: 'muenster',
     },
   ]

--- a/src/app/trajectory/inferences/inference.service.ts
+++ b/src/app/trajectory/inferences/inference.service.ts
@@ -10,13 +10,13 @@ export class InferenceService {
       name: 'Home',
       description: 'We do now know where your home is.',
       trajectoryId: 'muenster',
-      location: [51.968446, 7.60549],
+      lonLat: [51.968446, 7.60549],
       accuracy: 50,
     },
     {
       name: 'Workplace',
       description: 'We know where you work.',
-      location: [51.968446, 7.61249],
+      lonLat: [51.968446, 7.61249],
       trajectoryId: 'muenster',
     },
   ]

--- a/src/app/trajectory/inferences/inferences.page.html
+++ b/src/app/trajectory/inferences/inferences.page.html
@@ -19,8 +19,8 @@
   <app-item-card
     *ngFor="let i of inferences"
     icon="home-outline"
-    title="{{i.name}}"
-    subtitle="{{i.description}}"
+    title="{{formatInferenceName(i)}}"
+    subtitle="{{formatInferenceInfo(i)}}"
     (click)="showInferenceOnMap(i)"
   ></app-item-card>
 </ion-content>

--- a/src/app/trajectory/inferences/inferences.page.ts
+++ b/src/app/trajectory/inferences/inferences.page.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core'
 import { ActivatedRoute, Router } from '@angular/router'
+import { Inference } from 'src/app/model/inference'
 import { AllInferences } from 'src/app/shared-services/inferences/definitions'
 import { InferenceService } from './inference.service'
 

--- a/src/app/trajectory/inferences/inferences.page.ts
+++ b/src/app/trajectory/inferences/inferences.page.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core'
 import { ActivatedRoute, Router } from '@angular/router'
+import { AllInferences } from 'src/app/shared-services/inferences/definitions'
 import { InferenceService } from './inference.service'
 
 @Component({
@@ -13,12 +14,24 @@ export class InferencesPage implements OnInit {
   constructor(
     private service: InferenceService,
     private router: Router,
-    private route: ActivatedRoute,
+    private route: ActivatedRoute
   ) {}
 
   ngOnInit() {
     const trajId = this.route.snapshot.paramMap.get('trajectoryId')
     this.inferences = this.service.getInferences(trajId)
+  }
+
+  formatInferenceName(inference: Inference): string {
+    const def = AllInferences[inference.name]
+    if (!def) return inference.name
+    return def.name()
+  }
+
+  formatInferenceInfo(inference: Inference): string {
+    const def = AllInferences[inference.name]
+    if (!def) return `unknown inference ${inference.name}`
+    return def.info(inference)
   }
 
   showInferenceOnMap(inference: Inference) {

--- a/src/app/trajectory/inferences/inferences.page.ts
+++ b/src/app/trajectory/inferences/inferences.page.ts
@@ -36,8 +36,8 @@ export class InferencesPage implements OnInit {
   }
 
   showInferenceOnMap(inference: Inference) {
-    if (!inference.location || !inference.accuracy) return
-    this.openMap(inference.location)
+    if (!inference.lonLat || !inference.accuracy) return
+    this.openMap(inference.lonLat)
   }
 
   openMap(centerLatLng?: [number, number]) {

--- a/src/app/trajectory/map/map.page.ts
+++ b/src/app/trajectory/map/map.page.ts
@@ -85,8 +85,8 @@ export class MapPage implements OnInit, OnDestroy {
   private addInferenceMarkers(inferences: Inference[]) {
     this.inferenceMarkers.clearLayers()
     for (const inference of inferences) {
-      if (!inference.location || !inference.accuracy) continue
-      const m = new Circle(inference.location, {
+      if (!inference.lonLat || !inference.accuracy) continue
+      const m = new Circle(inference.lonLat, {
         radius: inference.accuracy,
       })
       m.addTo(this.inferenceMarkers).bindPopup(inference.name)

--- a/src/app/trajectory/map/map.page.ts
+++ b/src/app/trajectory/map/map.page.ts
@@ -11,6 +11,7 @@ import {
   tileLayer,
 } from 'leaflet'
 import { Subscription } from 'rxjs'
+import { Inference } from 'src/app/model/inference'
 import { TrajectoryType } from 'src/app/model/trajectory'
 import { TrajectoryService } from 'src/app/shared-services/trajectory.service'
 import { InferenceService } from '../inferences/inference.service'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,8 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2015",
-    "lib": [
-      "es2018",
-      "dom"
-    ]
+    "lib": ["es2018", "dom"],
+    "resolveJsonModule": true
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "importHelpers": true,
     "target": "es2015",
     "lib": ["es2018", "dom"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -2,17 +2,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "types": [
-      "jasmine",
-      "node"
-    ]
+    "types": ["jasmine", "node"],
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
   },
-  "files": [
-    "src/test.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.spec.ts",
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/test.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
This adds foundations for the inference engine;

1. API definition
    - this is based on a quick brainstorming, open for suggestions. We might want to pass in more parameters like a time interval for the maybe-upcoming time-slider concept.
2. stub teststuite (implementation of tests is tracked in #34
    - to run this use the new npm script. eg on linux with chromium:
        ```
        CHROME_BIN=`which chromium-browser` npm run test:inferences
        ```

aside:
This PR would be a good opportunity to rename `Inference.location` to a more specific `Inference.lonLat`, what do you think?

aside 2:
I tried the proposed commit message syntax `#<issue id> <summary>`, but this interferes with git CLI commit message editor due to leading `#`. so I put it in the back of the msg :)