### PR TITLE
WIP: release beta only on release-beta branch

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -3,7 +3,7 @@ name: CI-Android
 on:
   # Triggers the workflow on push or pull request events but only for the develop branch
   push:
-    branches: [ develop ]
+    branches: [ release-beta ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -3,7 +3,7 @@ name: CI-iOS
 on:
   # Triggers the workflow on push or pull request events but only for the develop branch
   push:
-    branches: [ develop ]
+    branches: [ release-beta ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SIMPORT Learning App
+
 learning tool on location privacy
 
 > **status**: prototyping
@@ -6,15 +7,18 @@ learning tool on location privacy
 > this is part of the [SIMPORT][simport] project
 
 ## development
+
 This is an hybrid [Ionic][ionic] app, using Capacitator (a drop-in replacement
 for Cordova) to access native APIs and [Angular][angular] for UI.
 
 ### version control
-We use `develop` as the main branch and build features on feature branches `feature/<feature name>`, merging into `develop`. For your commits, please use the following commit message if applicable: `#<issue number>: <commit message>`
 
-Releases are automatically triggered on push to `develop` using GitHub Actions
+We use `develop` as the main branch and build features on feature branches `feature/<feature name>`, merging into `develop`.For your commits, please use the following commit message if applicable: `#<issue number>: <commit message>`
+
+Releases are automatically triggered on push to `release-beta` using GitHub Actions & Firebase.
 
 ### dev env setup
+
 For basic UI development you'll only need [node.js][node] installed.
 Then run:
 
@@ -26,15 +30,18 @@ npm install               # install the frontend dependencies
 ```
 
 #### build for Android
+
 - install [Android Studio][android]
   - on linux, install to `/opt/android-studio/`, as this path is configured in `capacitor.config.json`
 - download Android SDK 29 (android studio settings > appearance > system settings > Android SDK)
 - build artifact will be `./android/app/build/outputs/apk/app-debug.apk`
 
 #### build for iOS
+
 TBD
 
 ### run & build
+
 ```sh
 # hot reloading server
 ionic serve
@@ -50,9 +57,10 @@ ionic cap build ios
 ```
 
 > NOTE: with Capacitor, the native build projects are supposed to be checked into version control!
->   This avoids duplicate config and simplifies writing native code without creating plugins.
+> This avoids duplicate config and simplifies writing native code without creating plugins.
 
 ### test
+
 tbd
 
 [simport]: https://simport.net/


### PR DESCRIPTION
as discussed, fixes #45

problem: we probably still want to have CI builds on `develop`, but push to firebase only from `release-beta`.
I'm not very experienced with GH actions, @schrooom can you help with that?

