### PR TITLE
make the src/* alias work for dev/*.ts

### DIFF
--- a/dev/generate_test_trajectory.ts
+++ b/dev/generate_test_trajectory.ts
@@ -1,11 +1,11 @@
-const USAGE = `ts-node --dir dev generate_test_trajectory.ts [ <gpx-file-home> <gpx-file-home-to-work> <gpx-file-work> <gpx-file-work-to-home> ]`
+const USAGE = `ts-node -r tsconfig-paths/register --dir dev generate_test_trajectory.ts [ <gpx-file-home> <gpx-file-home-to-work> <gpx-file-work> <gpx-file-work-to-home> ]`
 
-import { TestTrajectoryIO } from './test_trajectory_io'
 import {
   Trajectory,
   TrajectoryMeta,
   TrajectoryType,
-} from '../src/app/model/trajectory'
+} from 'src/app/model/trajectory'
+import { TestTrajectoryIO } from './test_trajectory_io'
 
 const isGpxExportEnabled = false
 const isCsvExportEnabled = false
@@ -18,10 +18,10 @@ type TrajectoryTestBase = {
 }
 
 const filepaths = {
-  home: 'test-data-gpx/track_home.gpx',
-  homeToWork: 'test-data-gpx/track_home_to_work.gpx',
-  work: 'test-data-gpx/track_work.gpx',
-  workToHome: 'test-data-gpx/track_work_to_home.gpx',
+  home: __dirname + '/test-data-gpx/track_home.gpx',
+  homeToWork: __dirname + '/test-data-gpx/track_home_to_work.gpx',
+  work: __dirname + '/test-data-gpx/track_work.gpx',
+  workToHome: __dirname + '/test-data-gpx/track_work_to_home.gpx',
 }
 
 const testDataNames = {

--- a/dev/import_example_trajectory.ts
+++ b/dev/import_example_trajectory.ts
@@ -1,13 +1,13 @@
 // assumptions:
 // - geojson is a feature of polyline with properties.timestamps being an array of iso8601 dates.
 
-const USAGE = `ts-node --dir dev import_example_trajectory.ts <gpx-or-geojson-file> <placename>`
+const USAGE = `ts-node -r tsconfig-paths/register --dir dev import_example_trajectory.ts <gpx-or-geojson-file> <placename>`
 
 import * as polyline from '@mapbox/polyline'
 import * as fs from 'fs'
 import * as GPX from 'gpx-parse'
 import * as path from 'path'
-import { Trajectory, TrajectoryType } from '../src/app/model/trajectory'
+import { Trajectory, TrajectoryType } from 'src/app/model/trajectory'
 
 function argparse() {
   const args = process.argv.slice(2)

--- a/dev/test_trajectory_io.ts
+++ b/dev/test_trajectory_io.ts
@@ -1,10 +1,11 @@
 import * as fs from 'fs'
-import * as path from 'path'
-import * as GPX from 'gpx-parse'
 import createGpx from 'gps-to-gpx'
+import * as GPX from 'gpx-parse'
+import * as path from 'path'
 import { Trajectory, TrajectoryType } from '../src/app/model/trajectory'
 
-const exportFilepath = '../src/app/shared-services/inferences/test-data/'
+const exportFilepath =
+  __dirname + '/../src/app/shared-services/inferences/test-data/'
 
 type Parser = (
   id: string,

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -8,6 +8,11 @@
     "downlevelIteration": true,
     "target": "es2015",
     "lib": ["es2018", "dom"],
-    "types": ["node"]
+    "types": ["node"],
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "paths": {
+      "src/*": ["../src/*"]
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "simport-learning",
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
@@ -75,6 +74,7 @@
         "prettier": "2.1.2",
         "protractor": "~7.0.0",
         "ts-node": "~8.3.0",
+        "tsconfig-paths": "^3.9.0",
         "tslint": "~6.1.0",
         "typescript": "~3.9.5"
       }
@@ -2791,6 +2791,12 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "node_modules/@types/leaflet": {
@@ -16210,6 +16216,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -16719,6 +16734,30 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
       }
     },
     "node_modules/tslib": {
@@ -21026,6 +21065,12 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "@types/leaflet": {
@@ -32341,6 +32386,12 @@
         }
       }
     },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -32748,6 +32799,29 @@
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
       "dev": true
+    },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
+      }
     },
     "tslib": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "test": "cd dev && npx ts-node generate_test_trajectory.ts ; ng test",
+    "test": "cd dev && npx ts-node -r tsconfig-paths/register generate_test_trajectory.ts ; ng test",
     "test:inferences": "ng test --include src/app/shared-services/inferences/",
     "lint": "prettier --loglevel=warn --write src/app && tslint -p . \"src/app/**/*.ts\"",
     "e2e": "ng e2e",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "prettier": "2.1.2",
     "protractor": "~7.0.0",
     "ts-node": "~8.3.0",
+    "tsconfig-paths": "^3.9.0",
     "tslint": "~6.1.0",
     "typescript": "~3.9.5"
   },


### PR DESCRIPTION
For standard build targets, we somehow have the `src/*` import alias available,
I'm unsure at which build stage this is applied (babel, called with some internal angular config..??)

This commit makes code that bypasses the angular build step (for running in node.js) aware of this alias:
Typescript can alias import paths, but doesn't emit this path mapping in it's JS output.
For this, we need another runtime dependency, which hooks via the ts-node `-r` flag into the node runtime.