### PR TITLE
upgrade @mauron/cordova-plugin/background-geolocation

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,9 +3,9 @@ name: Tests
 on:
   # Triggers the workflow on push or pull request events but only for the develop branch
   push:
-    branches: [ develop ]
+    branches: [develop]
   pull_request:
-    branches: [ develop ]
+    branches: [develop]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -13,22 +13,22 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
-        node-version: [14.15]
+        node-version: [15.14.0]
 
     steps:
       - name: Checkout project
         uses: actions/checkout@master
-      
+
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-          
+
       - name: Install dependencies
         run: npm install --silent
-        
+
       - name: Run tests
         run: npm test -- --no-watch --no-progress --browsers=ChromeHeadlessCI

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@ionic-native/status-bar": "^5.0.0",
         "@ionic/angular": "^5.0.0",
         "@mapbox/polyline": "^1.1.1",
-        "@mauron85/cordova-plugin-background-geolocation": "git+https://github.com/noerw/cordova-plugin-background-geolocation.git",
+        "@mauron85/cordova-plugin-background-geolocation": "git+https://github.com/noerw/cordova-plugin-background-geolocation.git#e08ab0f491f1cce738e986c0a493378eb3d6ff85",
         "@types/moment": "^2.13.0",
         "capacitor-file-selector": "0.0.5",
         "cordova-plugin-android-permissions": "^1.1.2",
@@ -2531,7 +2531,8 @@
     },
     "node_modules/@mauron85/cordova-plugin-background-geolocation": {
       "version": "3.1.0",
-      "resolved": "git+ssh://git@github.com/noerw/cordova-plugin-background-geolocation.git#d394da55a600683c39fe53096ee079afa454748b",
+      "resolved": "git+ssh://git@github.com/noerw/cordova-plugin-background-geolocation.git#e08ab0f491f1cce738e986c0a493378eb3d6ff85",
+      "integrity": "sha512-4tx1Mxu7WhO7iNjcwF3PKp3ATl6+XSoVxgMoCQup0Ko6g+TtQz3jV7VmCX/lPxK5D1aiuarlyH4mngdL8ys8Aw==",
       "license": "Apache-2.0",
       "engines": {
         "cordovaDependencies": {
@@ -20870,8 +20871,9 @@
       }
     },
     "@mauron85/cordova-plugin-background-geolocation": {
-      "version": "git+ssh://git@github.com/noerw/cordova-plugin-background-geolocation.git#d394da55a600683c39fe53096ee079afa454748b",
-      "from": "@mauron85/cordova-plugin-background-geolocation@git+https://github.com/noerw/cordova-plugin-background-geolocation.git"
+      "version": "git+ssh://git@github.com/noerw/cordova-plugin-background-geolocation.git#e08ab0f491f1cce738e986c0a493378eb3d6ff85",
+      "integrity": "sha512-4tx1Mxu7WhO7iNjcwF3PKp3ATl6+XSoVxgMoCQup0Ko6g+TtQz3jV7VmCX/lPxK5D1aiuarlyH4mngdL8ys8Aw==",
+      "from": "@mauron85/cordova-plugin-background-geolocation@git+https://github.com/noerw/cordova-plugin-background-geolocation.git#e08ab0f491f1cce738e986c0a493378eb3d6ff85"
     },
     "@ngtools/webpack": {
       "version": "10.0.8",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ionic-native/status-bar": "^5.0.0",
     "@ionic/angular": "^5.0.0",
     "@mapbox/polyline": "^1.1.1",
-    "@mauron85/cordova-plugin-background-geolocation": "git+https://github.com/noerw/cordova-plugin-background-geolocation.git",
+    "@mauron85/cordova-plugin-background-geolocation": "git+https://github.com/noerw/cordova-plugin-background-geolocation.git#e08ab0f491f1cce738e986c0a493378eb3d6ff85",
     "@types/moment": "^2.13.0",
     "capacitor-file-selector": "0.0.5",
     "cordova-plugin-android-permissions": "^1.1.2",


### PR DESCRIPTION
Builds failed with npm 7, because the background geolocation dependency used submodules (ref https://github.com/npm/cli/issues/2774)
I merged the git submodules in our fork of that dependency into a single repo, and this is the update to that newer version, as I'm not sure if/when we can expect a fix in npm..

also (presumably) fixes #16