### PR TITLE
Fix angular `--prod` build, enable in CI

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -28,12 +28,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      # TODO: add flag --prod (currently not building)
       - name: Run ionic build
         run: |
           npm install --silent
           ionic cap update --no-interactive --no-open --confirm
-          ionic cap build android --no-interactive --no-open --confirm
+          ionic cap build android --no-interactive --no-open --confirm --prod
 
       - name: Setup Android NDK
         uses: nttld/setup-ndk@v1.0.3

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           npm install --silent
           ionic cap update --no-interactive --no-open --confirm
-          ionic cap build ios --no-interactive --no-open --confirm
+          ionic cap build ios --no-interactive --no-open --confirm --prod
 
       - name: Bump version
         run: |

--- a/.github/workflows/distribute-android.yml
+++ b/.github/workflows/distribute-android.yml
@@ -28,12 +28,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      # TODO: add flag --prod (currently not building)
       - name: Run ionic build
         run: |
           npm install --silent
           ionic cap update --no-interactive --no-open --confirm
-          ionic cap build android --no-interactive --no-open --confirm
+          ionic cap build android --no-interactive --no-open --confirm --prod
 
       - name: Setup Android NDK
         uses: nttld/setup-ndk@v1.0.3

--- a/.github/workflows/distribute-ios.yml
+++ b/.github/workflows/distribute-ios.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           npm install --silent
           ionic cap update --no-interactive --no-open --confirm
-          ionic cap build ios --no-interactive --no-open --confirm
+          ionic cap build ios --no-interactive --no-open --confirm --prod
 
       - name: Bump version
         run: |

--- a/src/app/debug-window/debug-window.component.ts
+++ b/src/app/debug-window/debug-window.component.ts
@@ -12,7 +12,7 @@ import { TrajectoryService } from '../shared-services/trajectory.service'
   styleUrls: ['./debug-window.component.scss'],
 })
 export class DebugWindowComponent implements OnInit, OnDestroy {
-  myDevice: DeviceInfo
+  myDevice: Record<keyof DeviceInfo, any>
   trajectories: TrajectoryMeta[]
   userTrajectory: Trajectory
   importedTrajectories: TrajectoryMeta[]
@@ -31,7 +31,10 @@ export class DebugWindowComponent implements OnInit, OnDestroy {
   ) {}
 
   async ngOnInit() {
-    this.myDevice = await Plugins.Device.getInfo()
+    this.myDevice = (await Plugins.Device.getInfo()) as Record<
+      keyof DeviceInfo,
+      any
+    >
 
     this.subscriptions.push(
       this.trajectoryService.getAllMeta().subscribe((ts) => {

--- a/src/app/select-trajectory/select-trajectory.page.html
+++ b/src/app/select-trajectory/select-trajectory.page.html
@@ -10,7 +10,7 @@
       <ion-col sizeXs="12" sizeLg="4">
         <app-item-card
           [disabled]="!locationService.isSupportedPlatform"
-          (click)="locationService.isSupportedPlatform && enableTrajectory('tracking')"
+          (click)="locationService.isSupportedPlatform && enableTrajectory(TrajectoryMode.TRACK)"
           icon="locate-outline"
           title="Record your own trajectory"
           subtitle="get notified when information about you could be derived"
@@ -22,7 +22,7 @@
           icon="compass-outline"
           title="Explore trajectories"
           subtitle="interactively explore your own and somones whereabouts"
-          (click)="enableTrajectory('choose')"
+          (click)="enableTrajectory(TrajectoryMode.CHOOSE)"
         ></app-item-card>
       </ion-col>
 
@@ -32,7 +32,7 @@
           icon="add-outline"
           title="Add your own trajectory"
           subtitle="import a JSON file"
-          (click)="enableTrajectory('import')"
+          (click)="enableTrajectory(TrajectoryMode.IMPORT)"
         ></app-item-card>
       </ion-col>
     </ion-row>

--- a/src/app/select-trajectory/select-trajectory.page.ts
+++ b/src/app/select-trajectory/select-trajectory.page.ts
@@ -38,6 +38,7 @@ export class SelectTrajectoryPage {
   private CLICK_INTERVAL = 500
   private DEBUG_WINDOW_CLICKS = 8
   private lastOnClicks = [] // contains timestamps of title clicks, newest comes first
+  TrajectoryMode: typeof TrajectoryMode = TrajectoryMode // for usage in template
 
   // fired on title click
   // used for multiple click detection

--- a/src/app/shared-ui/shared-ui.module.ts
+++ b/src/app/shared-ui/shared-ui.module.ts
@@ -1,10 +1,11 @@
-import { NgModule } from '@angular/core'
 import { CommonModule } from '@angular/common'
+import { NgModule } from '@angular/core'
+import { IonicModule } from '@ionic/angular'
 import { ItemCardComponent } from './item-card/item-card.component'
 
 @NgModule({
   declarations: [ItemCardComponent],
-  imports: [CommonModule],
+  imports: [CommonModule, IonicModule],
   exports: [ItemCardComponent],
 })
 export class SharedUiModule {}

--- a/src/app/tracking/tracking.page.html
+++ b/src/app/tracking/tracking.page.html
@@ -45,5 +45,4 @@
         ></ion-toggle> </ion-col
     ></ion-row>
   </ion-grid>
-  <div style="white-space: pre-wrap">{{ eventText }}</div>
 </ion-content>

--- a/src/app/tracking/tracking.page.ts
+++ b/src/app/tracking/tracking.page.ts
@@ -15,17 +15,16 @@ export class TrackingPage implements OnInit, OnDestroy {
   @Input() state: string
   @Input() stateIcon: string
   @Input() notificationsEnabled: boolean
+  trajectoryExists: boolean
 
   private locationServiceStateSubscription: Subscription
   private locationServiceNotificationToggleSubscription: Subscription
   private trajectoryServiceSubscription: Subscription
 
-  private trajectoryExists: boolean
-
   constructor(
     private zone: NgZone,
     public platform: Platform,
-    private locationService: LocationService,
+    public locationService: LocationService,
     private trajectoryService: TrajectoryService,
     private router: Router
   ) {}

--- a/src/app/trajectory/map/map.page.html
+++ b/src/app/trajectory/map/map.page.html
@@ -80,7 +80,7 @@
     >
       <ion-icon name="filter"></ion-icon>
     </ion-fab-button>
-    <ion-fab-button (click)="showInferences($event)">
+    <ion-fab-button (click)="showInferences()">
       <ion-icon name="analytics-outline"></ion-icon>
     </ion-fab-button>
   </ion-fab>

--- a/src/app/trajectory/map/map.page.ts
+++ b/src/app/trajectory/map/map.page.ts
@@ -44,18 +44,18 @@ export class MapPage implements OnInit, OnDestroy {
   inferenceMarkers = new LayerGroup()
   lastLocation: CircleMarker
 
+  // inference controls
+  showInferenceControls = false
+  showHomeInferences = true
+  showWorkInferences = true
+  currentConfidenceThreshold = 50
+  currentInferences: Inference[]
+
   // should only be used for invalidateSize(), content changes via directive bindings!
   private map: Map | undefined
   private trajSub: Subscription
   private trajectoryId: string
   private trajectoryType: TrajectoryType
-  private currentInferences: Inference[]
-
-  // inference controls
-  private showInferenceControls = false
-  private showHomeInferences = true
-  private showWorkInferences = true
-  private currentConfidenceThreshold = 50
 
   constructor(
     private inferenceService: InferenceService,
@@ -145,7 +145,7 @@ export class MapPage implements OnInit, OnDestroy {
     }
   }
 
-  private updateInferenceMarkers() {
+  updateInferenceMarkers() {
     const inferences = this.currentInferences.filter(
       (i) =>
         i.lonLat &&


### PR DESCRIPTION
`ionic build` / `ng build` with `--prod` previously failed due to much stricter typechecking than in development builds.
This PR fixes the type issues, and enables `--prod` for CI builds.
The app will be a bit [smaller and potentially faster with this flag](https://angular.io/guide/deployment#production-optimizations).