### PR TITLE
#102 add functionality to cluster staypoints

### DIFF
--- a/src/app/model/staypoints.ts
+++ b/src/app/model/staypoints.ts
@@ -2,10 +2,18 @@ export interface StayPointData {
   coordinates: [number, number][]
   starttimes: Date[]
   endtimes: Date[]
+  observationcount: number[]
 }
 
 export interface StayPoints extends StayPointData {
   trajID: string
+}
+
+export interface StayPointCluster {
+  trajID: string
+  coordinates: [number, number]
+  onSiteTimes: [Date, Date][]
+  observationcount: number
 }
 
 declare var require: any
@@ -28,6 +36,41 @@ export function writeStaypointsToGeoJSON(sp: StayPoints, path: string) {
       properties: {
         starttime: sp.starttimes[i],
         endtime: sp.endtimes[i],
+        observationcount: sp.observationcount[i],
+      },
+    })
+  }
+  const data = JSON.stringify(geojson)
+  const fs = require('fs')
+  fs.writeFile(path, data, (err) => {
+    if (err) {
+      console.log(err)
+    }
+  })
+}
+
+export function writeStaypointClusterArrayToGeoJSON(
+  spcs: StayPointCluster[],
+  path: string
+) {
+  const geojson = {
+    name: 'StayPointClusters',
+    type: 'FeatureCollection',
+    features: [],
+    properties: {
+      trajID: spcs[0].trajID,
+    },
+  }
+  for (const spc of spcs) {
+    geojson.features.push({
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [spc.coordinates[1], spc.coordinates[0]],
+      },
+      properties: {
+        onSiteTimes: spc.onSiteTimes,
+        observationcount: spc.observationcount,
       },
     })
   }

--- a/src/app/shared-services/db/migrations.ts
+++ b/src/app/shared-services/db/migrations.ts
@@ -110,6 +110,7 @@ export const MIGRATIONS = [
     lon FLOAT NOT NULL,
     starttime DATETIME NOT NULL,
     endtime DATETIME NOT NULL,
+    observationcount FLOAT NOT NULL,
     PRIMARY KEY (trajectory, starttime),
     FOREIGN KEY (trajectory) REFERENCES trajectories(id) ON DELETE CASCADE);`,
 ]

--- a/src/app/shared-services/db/sqlite.service.ts
+++ b/src/app/shared-services/db/sqlite.service.ts
@@ -344,13 +344,20 @@ export class SqliteService {
     // empty staypoints are to be expected and are handled in sp service
     if (!values.length) return undefined
     const data = values.reduce<StayPoints>(
-      (d, { trajectory, lat, lon, starttime, endtime }) => {
+      (d, { trajectory, lat, lon, starttime, endtime, observationcount }) => {
         d.coordinates.push([lat, lon])
         d.starttimes.push(convertTimestampToDate(starttime))
         d.endtimes.push(convertTimestampToDate(endtime))
+        d.observationcount.push(observationcount)
         return d
       },
-      { trajID: trajectoryId, coordinates: [], starttimes: [], endtimes: [] }
+      {
+        trajID: trajectoryId,
+        coordinates: [],
+        starttimes: [],
+        endtimes: [],
+        observationcount: [],
+      }
     )
     return data
   }
@@ -375,8 +382,16 @@ export class SqliteService {
         const [lat, lon] = stayPoints.coordinates[pointsIndex]
         const starttime = stayPoints.starttimes[pointsIndex]
         const endtime = stayPoints.endtimes[pointsIndex]
-        placeholders.push(`(?,?,?,?,?)`)
-        values.push(trajectoryId, lat, lon, starttime, endtime)
+        const observationcount = stayPoints.observationcount[pointsIndex]
+        placeholders.push(`(?,?,?,?,?,?)`)
+        values.push(
+          trajectoryId,
+          lat,
+          lon,
+          starttime,
+          endtime,
+          observationcount
+        )
       }
       const placeholderString = placeholders.join(', ')
       const statement = `INSERT OR REPLACE INTO staypoints VALUES ${placeholderString}`

--- a/src/app/shared-services/staypoint/staypoint-clusterer.ts
+++ b/src/app/shared-services/staypoint/staypoint-clusterer.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@angular/core'
+import { StayPointCluster, StayPoints } from 'src/app/model/staypoints'
+import clustering from 'density-clustering'
+import haversine from 'haversine-distance'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class StaypointClusterer {
+  /**
+   * Turn staypoints into cluster of staypoints using dbscan, disregarding staypoints with too few observations/time
+   * @param  stayPoints The input staypoints.
+   * @param  minObervationsPerHour The minimum observations per hour required for a staypoint to be considered in the clustering.
+   * E.g. with a value of 1/24, a staypoint with length 24.1 hours is only considered if it has at least 2 observations.
+   * This is a temporary measure until we log when gps tracking is active.
+   * @return The clusters of staypoints
+   */
+  public clusterStayPoints(
+    stayPoints: StayPoints,
+    minObervationsPerHour: number
+  ): StayPointCluster[] {
+    const stayPointsFiltered = this.dropSparseStaypoints(
+      stayPoints,
+      minObervationsPerHour
+    )
+    if (stayPointsFiltered.coordinates.length === 0) return undefined
+    const clusters = this.applyClustering(stayPointsFiltered)
+    return this.assembleStayPointClusters(stayPointsFiltered, clusters)
+  }
+
+  // drop Staypoints that have fewer observations per hour than the threshold
+  private dropSparseStaypoints(
+    stayPoints: StayPoints,
+    minObervationsPerHour
+  ): StayPoints {
+    const msInOneHour = 60 * 60 * 1000
+    // array indicating for each staypoint whether it has more obs per hour than threshold
+    const enoughObservations = stayPoints.endtimes.map((value, index) => {
+      const lengthInHrs =
+        (value.getTime() - stayPoints.starttimes[index].getTime()) / msInOneHour
+      const density = stayPoints.observationcount[index] / lengthInHrs
+      return density >= minObervationsPerHour
+    })
+    const stayPointsFiltered: StayPoints = {
+      trajID: stayPoints.trajID,
+      coordinates: stayPoints.coordinates.filter(
+        (value, index) => enoughObservations[index]
+      ),
+      starttimes: stayPoints.starttimes.filter(
+        (value, index) => enoughObservations[index]
+      ),
+      endtimes: stayPoints.endtimes.filter(
+        (value, index) => enoughObservations[index]
+      ),
+      observationcount: stayPoints.observationcount.filter(
+        (value, index) => enoughObservations[index]
+      ),
+    }
+    return stayPointsFiltered
+  }
+
+  // clusters staypoints by spatial proximity
+  private applyClustering(stayPoints: StayPoints): number[][] {
+    const dbscan = new clustering.DBSCAN()
+    // parameters: neighborhood radius, number of points in neighborhood to form a cluster
+    // number of points for cluster set to one as we dont care if outliers get their own cluster
+    const clusters = dbscan.run(
+      stayPoints.coordinates,
+      11,
+      1,
+      this.computeHaversineDistance
+    )
+    return clusters
+  }
+
+  // fit clusters into staypointcluster datastructure, coords of cluster is mean of members
+  private assembleStayPointClusters(
+    stayPointsFiltered: StayPoints,
+    clusters: number[][]
+  ): StayPointCluster[] {
+    const stayPointClusters: StayPointCluster[] = []
+    let currentCluster: StayPointCluster
+    let clusterCoordinates: [number, number][]
+    let clusterTimes: [Date, Date][]
+    let observationCounts: number[]
+    for (const cluster of clusters) {
+      clusterCoordinates = cluster.map((x) => stayPointsFiltered.coordinates[x])
+      clusterTimes = cluster.map((x) => {
+        return [
+          stayPointsFiltered.starttimes[x],
+          stayPointsFiltered.endtimes[x],
+        ]
+      })
+      observationCounts = cluster.map(
+        (x) => stayPointsFiltered.observationcount[x]
+      )
+      currentCluster = {
+        trajID: stayPointsFiltered.trajID,
+        coordinates: this.computeMeanCoords(clusterCoordinates),
+        onSiteTimes: clusterTimes,
+        observationcount: observationCounts.reduce((a, b) => a + b, 0),
+      }
+      stayPointClusters.push(currentCluster)
+    }
+    return stayPointClusters
+  }
+
+  private computeHaversineDistance(
+    firstCoordinate: [number, number],
+    secondCoordinate: [number, number]
+  ): number {
+    const a = { latitude: firstCoordinate[0], longitude: firstCoordinate[1] }
+    const b = { latitude: secondCoordinate[0], longitude: secondCoordinate[1] }
+    return haversine(a, b)
+  }
+
+  // compute arithmetic mean of coords
+  private computeMeanCoords(coords: [number, number][]): [number, number] {
+    let meanLat = 0
+    let meanLong = 0
+    coords.forEach((point) => {
+      meanLat += point[0]
+      meanLong += point[1]
+    })
+    meanLat = meanLat / coords.length
+    meanLong = meanLong / coords.length
+    return [meanLat, meanLong]
+  }
+}

--- a/src/app/shared-services/staypoint/staypoint-detector.ts
+++ b/src/app/shared-services/staypoint/staypoint-detector.ts
@@ -28,15 +28,18 @@ export class StaypointDetector {
     const length = coords.length
     let i = 0 // i (index into coords) is the current candidate for staypoint
     let j = 0 // j (index into coords) is the next point we compare to i to see whether we left the staypoint
+    let numberOfObservations = 0 // number of observations in current staypoint
     let dist: number
     let timeDelta: number
     const staypoints: StayPointData = {
       coordinates: [],
       starttimes: [],
       endtimes: [],
+      observationcount: [],
     }
     while (i < length && j < length) {
       j = i + 1
+      numberOfObservations += 1
       while (j < length) {
         dist = this.computeHaversineDistance(coords[i], coords[j])
         // if j is within distance of i, it is part of this potential staypoint...
@@ -51,11 +54,14 @@ export class StaypointDetector {
             staypoints.starttimes.push(times[i])
             // end of staypoint is start of first moving point
             staypoints.endtimes.push(times[j])
+            staypoints.observationcount.push(numberOfObservations)
           }
           i = j
+          numberOfObservations = 0
           break
         }
         j += 1
+        numberOfObservations += 1
       }
     }
     // If we spent a lot of time near the last i, we add it as staypoint even though we never left it
@@ -70,6 +76,7 @@ export class StaypointDetector {
         )
         staypoints.starttimes.push(times[i])
         staypoints.endtimes.push(times[j])
+        staypoints.observationcount.push(numberOfObservations)
       }
     }
     return staypoints

--- a/src/app/shared-services/staypoint/staypoint.service.spec.fixtures.ts
+++ b/src/app/shared-services/staypoint/staypoint.service.spec.fixtures.ts
@@ -35,12 +35,14 @@ export const homeWorkStayPoints: StayPoints = {
     new Date('2021-02-25T08:39:04.541Z'),
   ],
   trajID: 'randomId',
+  observationcount: [157, 121, 163],
 }
 export const cutHomeWorkStayPoints: StayPoints = {
-  coordinates: homeWorkStayPoints.coordinates.slice(0, 1),
-  starttimes: homeWorkStayPoints.starttimes.slice(0, 1),
-  endtimes: homeWorkStayPoints.endtimes.slice(0, 1),
+  coordinates: homeWorkStayPoints.coordinates.slice(0, 2),
+  starttimes: homeWorkStayPoints.starttimes.slice(0, 2),
+  endtimes: homeWorkStayPoints.endtimes.slice(0, 2),
   trajID: 'randomId',
+  observationcount: homeWorkStayPoints.observationcount.slice(0, 2),
 }
 export const cutTrajData: TrajectoryData = {
   coordinates: [homeWorkTrajData.coordinates[0]],
@@ -52,4 +54,5 @@ export const emptyStayPoints: StayPoints = {
   coordinates: [],
   starttimes: [],
   endtimes: [],
+  observationcount: [],
 }

--- a/src/app/shared-services/staypoint/staypoint.service.spec.ts
+++ b/src/app/shared-services/staypoint/staypoint.service.spec.ts
@@ -182,6 +182,34 @@ describe('StaypointService', () => {
       done()
     })
   })
+
+  it('#computeStayPointClusters should compute nothing for empty staypoints', (done: DoneFn) => {
+    sqliteServiceSpy.getStaypoints.and.returnValue(Promise.resolve(undefined))
+    service
+      .computeStayPointClusters(TrajectoryType.USERTRACK, 'randomId')
+      .then((value) => {
+        expect(value).toEqual(undefined)
+        expect(sqliteServiceSpy.getStaypoints).toHaveBeenCalledOnceWith(
+          'randomId'
+        )
+        done()
+      })
+  })
+
+  it('#computeStayPointClusters should compute two clusters for staypoints from home-work trajectory', (done: DoneFn) => {
+    sqliteServiceSpy.getStaypoints.and.returnValue(
+      Promise.resolve(fixtures.homeWorkStayPoints)
+    )
+    service
+      .computeStayPointClusters(TrajectoryType.USERTRACK, 'randomId')
+      .then((value) => {
+        expect(value.length).toEqual(2)
+        expect(sqliteServiceSpy.getStaypoints).toHaveBeenCalledOnceWith(
+          'randomId'
+        )
+        done()
+      })
+  })
 })
 
 function areStayPointsSimilar(sp1: StayPoints, sp2: StayPoints): boolean {
@@ -189,7 +217,8 @@ function areStayPointsSimilar(sp1: StayPoints, sp2: StayPoints): boolean {
     sp1.trajID !== sp2.trajID ||
     sp1.coordinates.length !== sp2.coordinates.length ||
     sp1.starttimes.length !== sp2.endtimes.length ||
-    sp1.starttimes.length !== sp2.endtimes.length
+    sp1.starttimes.length !== sp2.endtimes.length ||
+    sp1.observationcount.length !== sp2.observationcount.length
   ) {
     return false
   }
@@ -204,7 +233,8 @@ function areStayPointsSimilar(sp1: StayPoints, sp2: StayPoints): boolean {
       Math.abs(sp1.starttimes[i].getTime() - sp2.starttimes[i].getTime()) >
         precisionMs ||
       Math.abs(sp1.endtimes[i].getTime() - sp2.endtimes[i].getTime()) >
-        precisionMs
+        precisionMs ||
+      sp1.observationcount[i] !== sp2.observationcount[i]
     ) {
       return false
     }

--- a/src/app/shared-services/staypoint/staypoint.service.ts
+++ b/src/app/shared-services/staypoint/staypoint.service.ts
@@ -5,24 +5,28 @@ import {
   TrajectoryData,
   TrajectoryType,
 } from 'src/app/model/trajectory'
-import { StayPoints } from 'src/app/model/staypoints'
+import { StayPointCluster, StayPoints } from 'src/app/model/staypoints'
 import { TrajectoryService } from '../trajectory/trajectory.service'
 import { take } from 'rxjs/operators'
 import { StaypointDetector } from './staypoint-detector'
+import { StaypointClusterer } from './staypoint-clusterer'
 
 @Injectable({
   providedIn: 'root',
 })
 export class StaypointService {
-  // for meaning of these two parameters, please see detectStayPoints() documentation
+  // for meaning of these two parameters, please see staypointDetector.detectStayPoints() documentation
   // if you change one or both, please also update the associated detected staypoints in staypoint.service.spec.fixtures.ts
   static readonly DIST_THRESH_METERS = 100
   static readonly TIME_THRESH_MINUTES = 15
+  // for meaning of this parameter, please see staypointClusterer.clusterStayPoints() documentation
+  static readonly MIN_OBSERVATIONS_PER_HOUR = 1 / 24
 
   constructor(
     private db: SqliteService,
     private trajService: TrajectoryService,
-    private staypointDetector: StaypointDetector
+    private staypointDetector: StaypointDetector,
+    private staypointClusterer: StaypointClusterer
   ) {}
 
   /**
@@ -75,6 +79,7 @@ export class StaypointService {
         coordinates: spData.coordinates,
         starttimes: spData.starttimes,
         endtimes: spData.endtimes,
+        observationcount: spData.observationcount,
       }
       await this.db.upsertStaypoints(trajectoryId, spReturn)
       return
@@ -100,8 +105,33 @@ export class StaypointService {
         .slice(0, -1)
         .concat(newSpData.starttimes),
       endtimes: oldStayPoints.endtimes.slice(0, -1).concat(newSpData.endtimes),
+      observationcount: oldStayPoints.observationcount
+        .slice(0, -1)
+        .concat(newSpData.observationcount),
     }
     await this.db.upsertStaypoints(trajectoryId, updatedStaypoints)
+  }
+
+  /**
+   * Return array of staypoint clusters from saved staypoints for given trajectoryID
+   * (for newest staypoints, call updateStaypoines() first),
+   * disregarding staypoints that have a very low density of observations per time.
+   * @param trajectoryType The type of the trajectory to which staypoints belong.
+   * @param trajectoryId The identifier of the trajectory to which staypoints belong.
+   * @return An array of staypoint clusters.
+   */
+  async computeStayPointClusters(
+    trajectoryType: TrajectoryType,
+    trajectoryId: string
+  ): Promise<StayPointCluster[]> {
+    const stayPoints: StayPoints = await this.db.getStaypoints(trajectoryId)
+    if (stayPoints === undefined || stayPoints.coordinates.length === 0)
+      return undefined
+    const stayPointClusters = await this.staypointClusterer.clusterStayPoints(
+      stayPoints,
+      StaypointService.MIN_OBSERVATIONS_PER_HOUR
+    )
+    return stayPointClusters
   }
 
   // return final part of provided trajectory, starting at or after starttime of last of provided staypoints


### PR DESCRIPTION
add functionality to cluster staypoints and provide these clusters in a data structure for further analysis. In order to deal with longer periods where GPS tracking has been turned off, only staypoints with sufficiently many observations per unit of time are considered. For this, the number of observations for each staypoint is computed and persisted. The cutoff for insufficient observations/time is set as a parameter in the staypoint service, similar to the two parameters in the staypoint detection algorithm. 