### PR TITLE
#108: tune staypoint engine params

### DIFF
--- a/src/app/shared-services/staypoint/staypoint.service.ts
+++ b/src/app/shared-services/staypoint/staypoint.service.ts
@@ -17,11 +17,11 @@ import { StaypointClusterer } from './staypoint-clusterer'
 export class StaypointService {
   // for meaning of these two parameters, please see StaypointDetector.detectStayPoints() documentation
   // if you change one or both, please also update the associated detected staypoints in staypoint.service.spec.fixtures.ts
-  static readonly DIST_THRESH_METERS = 150
-  static readonly TIME_THRESH_MINUTES = 15
+  static readonly DIST_THRESH_METERS = 200
+  static readonly TIME_THRESH_MINUTES = 30
 
   // for meaning of these two parameters, please see StaypointClusterer.clusterStayPoints() documentation
-  static readonly CLUSTERING_NEIGHBORHOOD_RADIUS = 11
+  static readonly CLUSTERING_NEIGHBORHOOD_RADIUS = 15
   static readonly CLUSTERING_POINTS_IN_NEIGHBORHOOD = 3
 
   constructor(

--- a/src/app/shared-services/staypoint/staypoint.service.ts
+++ b/src/app/shared-services/staypoint/staypoint.service.ts
@@ -17,8 +17,8 @@ import { StaypointClusterer } from './staypoint-clusterer'
 export class StaypointService {
   // for meaning of these two parameters, please see StaypointDetector.detectStayPoints() documentation
   // if you change one or both, please also update the associated detected staypoints in staypoint.service.spec.fixtures.ts
-  static readonly DIST_THRESH_METERS = 200
-  static readonly TIME_THRESH_MINUTES = 30
+  static readonly DIST_THRESH_METERS = 150
+  static readonly TIME_THRESH_MINUTES = 15
 
   // for meaning of these two parameters, please see StaypointClusterer.clusterStayPoints() documentation
   static readonly CLUSTERING_NEIGHBORHOOD_RADIUS = 15


### PR DESCRIPTION
closes #108 

`DIST_THRESH_METERS` and `TIME_THRESH_MINUTES` based on https://dl.acm.org/doi/abs/10.1145/1463434.1463477 and  `CLUSTERING_NEIGHBORHOOD_RADIUS` based on tuning with own trajectory