### PR TITLE
#167: fix cache ownership

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Repair cache-files ownership
+        run: sudo chown -R 501:20 "/Users/runner/.npm"
+
       - name: Run ionic build
         run: |
           npm install npm@8 -g


### PR DESCRIPTION
Closes #167.

```
npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /Users/runner/.npm/_cacache/content-v2/sha1/ee/28
npm ERR! errno -13
npm ERR! 
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR! 
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 501:20 "/Users/runner/.npm" // → this is what was added to the workflow
```

If I understood correctly, the added repairing command is obsolete after running once.