### PR TITLE
Fix for iOS-build

### DIFF
--- a/.github/workflows/distribute-android.yml
+++ b/.github/workflows/distribute-android.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run ionic build
         run: |
           npm install npm@8 -g
-          npm ci --silent
+          npm ci
           ionic cap build android --no-interactive --no-open --confirm --prod
 
       - name: Setup Android NDK

--- a/.github/workflows/distribute-ios.yml
+++ b/.github/workflows/distribute-ios.yml
@@ -28,10 +28,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Repair cache-files ownership
+        run: sudo chown -R 501:20 "/Users/runner/.npm"
+
       - name: Run ionic build
         run: |
           npm install npm@8 -g
-          npm ci --silent
+          npm ci
           ionic cap build ios --no-interactive --no-open --confirm --prod
 
       - name: Bump version


### PR DESCRIPTION
→ Enable logging for npm ci and add cache-ownership-fix to distribute-ios