### PR TITLE
#228: update firebase authentication method

### DIFF
--- a/.github/workflows/distribute-ios.yml
+++ b/.github/workflows/distribute-ios.yml
@@ -80,10 +80,18 @@ jobs:
           name: ipa-artifact
           path: ./
 
+      - name: Decode application credentials to JSON file
+        uses: timheuer/base64-to-file@v1.1
+        id: decode-application-credentials
+        with:
+          fileName: 'application-credentials.json'
+          fileDir: './app_distribution/'
+          encodedString: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+
       - name: Deploy to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1.3.4
         with:
           appId: ${{ secrets.FIREBASE_IOS_APP_ID }}
-          token: ${{ secrets.FIREBASE_TOKEN }}
+          serviceCredentialsFile: ${{ steps.decode-application-credentials.outputs.filePath }}
           groups: ${{ secrets.FIREBASE_INTERNAL_TEST_GROUP }}
           file: output.ipa


### PR DESCRIPTION
closes #228 

Replacing the old `FIREBASE_TOKEN` with the new `GOOGLE_APPLICATION_CREDENTIALS` file. The file is saved as base64 in the repository secrets and will be decoded during the action runtime.