### PR TITLE
Fix GitHub action warning

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -26,7 +26,7 @@ jobs:
         uses: coturiv/setup-ionic@master
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -37,13 +37,14 @@ jobs:
           ionic cap build android --no-interactive --no-open --confirm --prod
 
       - name: Setup Android NDK
-        uses: nttld/setup-ndk@v1.0.3
+        uses: nttld/setup-ndk@v1.2.0
         with:
           ndk-version: r21d
 
       - name: Setup JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 11
 
       - name: Setup Android keystore
@@ -55,7 +56,7 @@ jobs:
           ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE }}
 
       - name: Bump version
-        uses: chkfung/android-version-actions@v1.1
+        uses: chkfung/android-version-actions@v1.2.1
         with:
           gradlePath: ./android/app/build.gradle
           versionCode: ${{ github.run_number }}

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@master
 
-      - name: Prepare ionic build
-        uses: coturiv/setup-ionic@master
-
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Install Ionic
+        run: npm install -g @ionic/cli
 
       - name: Run ionic build
         run: |

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-ios:
-    runs-on: macOS-12
+    runs-on: macos-12
 
     strategy:
       matrix:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@master
 
-      - name: Prepare ionic build
-        uses: coturiv/setup-ionic@master
-
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Install Ionic
+        run: npm install -g @ionic/cli
 
       - name: Repair cache-files ownership
         run: sudo chown -R 501:20 "/Users/runner/.npm"

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -26,7 +26,7 @@ jobs:
         uses: coturiv/setup-ionic@master
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/distribute-android.yml
+++ b/.github/workflows/distribute-android.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@master
 
-      - name: Prepare ionic build
-        uses: coturiv/setup-ionic@master
-
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Install Ionic
+        run: npm install -g @ionic/cli
 
       - name: Run ionic build
         run: |

--- a/.github/workflows/distribute-android.yml
+++ b/.github/workflows/distribute-android.yml
@@ -24,7 +24,7 @@ jobs:
         uses: coturiv/setup-ionic@master
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -35,13 +35,14 @@ jobs:
           ionic cap build android --no-interactive --no-open --confirm --prod
 
       - name: Setup Android NDK
-        uses: nttld/setup-ndk@v1.0.3
+        uses: nttld/setup-ndk@v1.2.0
         with:
           ndk-version: r21d
 
       - name: Setup JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 11
 
       - name: Setup Android keystore
@@ -53,7 +54,7 @@ jobs:
           ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE }}
 
       - name: Bump version
-        uses: chkfung/android-version-actions@v1.1
+        uses: chkfung/android-version-actions@v1.2.1
         with:
           gradlePath: ./android/app/build.gradle
           versionCode: ${{ github.run_number }}

--- a/.github/workflows/distribute-ios.yml
+++ b/.github/workflows/distribute-ios.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@master
 
-      - name: Prepare ionic build
-        uses: coturiv/setup-ionic@master
-
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Install Ionic
+        run: npm install -g @ionic/cli
 
       - name: Repair cache-files ownership
         run: sudo chown -R 501:20 "/Users/runner/.npm"

--- a/.github/workflows/distribute-ios.yml
+++ b/.github/workflows/distribute-ios.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-ios:
-    runs-on: macOS-12
+    runs-on: macos-12
 
     strategy:
       matrix:

--- a/.github/workflows/distribute-ios.yml
+++ b/.github/workflows/distribute-ios.yml
@@ -24,7 +24,7 @@ jobs:
         uses: coturiv/setup-ionic@master
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/release-beta-android.yml
+++ b/.github/workflows/release-beta-android.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@master
 
-      - name: Prepare ionic build
-        uses: coturiv/setup-ionic@master
-
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Install Ionic
+        run: npm install -g @ionic/cli
 
       - name: Run ionic build
         run: |

--- a/.github/workflows/release-beta-android.yml
+++ b/.github/workflows/release-beta-android.yml
@@ -24,7 +24,7 @@ jobs:
         uses: coturiv/setup-ionic@master
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -35,13 +35,14 @@ jobs:
           ionic cap build android --no-interactive --no-open --confirm --prod
 
       - name: Setup Android NDK
-        uses: nttld/setup-ndk@v1.0.3
+        uses: nttld/setup-ndk@v1.2.0
         with:
           ndk-version: r21d
 
       - name: Setup JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 11
 
       - name: Setup Android keystore
@@ -53,7 +54,7 @@ jobs:
           ANDROID_KEYSTORE: ${{ secrets.GOOGLE_PLAY_ANDROID_KEYSTORE }}
 
       - name: Bump version
-        uses: chkfung/android-version-actions@v1.1
+        uses: chkfung/android-version-actions@v1.2.1
         with:
           gradlePath: ./android/app/build.gradle
           versionCode: ${{ github.run_number }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
⬆️ Updated:
- https://github.com/actions/setup-node (v2 -> v3)
- https://github.com/nttld/setup-ndk (v1.0.3 -> v1.2.0)
- https://github.com/actions/setup-java (v1 -> v3)
- https://github.com/chkfung/android-version-actions (v1.1 -> v1.2.1)

🚮 Removed:
- https://github.com/coturiv/setup-ionic (and replaced by manually installing ionic `npm install -g @ionic/cli` [b5229f0](https://github.com/sitcomlab/simport-learning-app/pull/279/commits/b5229f0cd234c8347d616f6b31a8a0bb20d1bb8b))

➡️ No update available:
- https://github.com/yukiarrr/ios-build-action

closes #248 