### PR TITLE
#293: distribute `study` branch on google play

### DIFF
--- a/.github/workflows/release-beta-android.yml
+++ b/.github/workflows/release-beta-android.yml
@@ -1,9 +1,9 @@
 name: Google-Play-Android-Distribution
 
 on:
-  # Triggers the workflow on push or pull request events but only for the study-1 branch
+  # Triggers the workflow on push or pull request events but only for the study branch
   push:
-    branches: [study-1]
+    branches: [study]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Related to #293

Builds and publishes the App on Google Play using the `study` branch.  