### PR TITLE
#299: create db before checking encryption

### DIFF
--- a/src/app/shared-services/db/sqlite.service.ts
+++ b/src/app/shared-services/db/sqlite.service.ts
@@ -643,6 +643,27 @@ export class SqliteService {
   private async initDb() {
     this.sqliteConnection = new SQLiteConnection(this.sqlitePlugin)
 
+    const isDatabase = await this.sqliteConnection.isDatabase(
+      SqliteService.databaseName
+    )
+
+    // create the database if it doesn't exist
+    if (!isDatabase.result) {
+      this.db = await this.sqliteConnection.createConnection(
+        SqliteService.databaseName,
+        false,
+        'no-encryption',
+        1,
+        false
+      )
+      await this.db.open()
+      await this.db.close()
+      await this.sqliteConnection.closeConnection(
+        SqliteService.databaseName,
+        false
+      )
+    }
+
     // check if DB is encrypted and set secret if not
     const isEncrypted = await this.sqliteConnection.isDatabaseEncrypted(
       SqliteService.databaseName


### PR DESCRIPTION
When the app starts for the first time, there was no database file in the filesystem. That's why the `isDatabaseEncrypted` function failed. 

In this PR we are checking if the database exists. If not, we are creating a temporarily connection which creates the database file in the filesystem. During the `isDatabaseEncrypted` function, there should now always be an existing database.

Closes #299 