### PR TITLE
Feature/fix export

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component } from '@angular/core'
 import { StatusBar, Style } from '@capacitor/status-bar'
 
-import { Platform } from '@ionic/angular'
+import { AlertController, Platform } from '@ionic/angular'
 import { TranslateService } from '@ngx-translate/core'
 
 import {
@@ -24,9 +24,12 @@ export class AppComponent implements AfterViewInit {
   activeAuthentication = new BehaviorSubject(false)
   lastSuccessfulAuthentication = new BehaviorSubject(-1)
 
+  private authenticationAlert?: HTMLIonAlertElement = undefined
+
   constructor(
     private platform: Platform,
-    private translateService: TranslateService
+    private translateService: TranslateService,
+    private alertController: AlertController
   ) {
     // init translation with browser-language (== device-language)
     this.translateService.addLangs(['en', 'de'])
@@ -85,12 +88,33 @@ export class AppComponent implements AfterViewInit {
         ]
 
         if (noCredentialsError.includes(code)) {
-          alert(this.translateService.instant('pinLock.noAuthMessage'))
+          this.showAlert(this.translateService.instant('pinLock.noAuthMessage'))
         } else {
-          alert(message)
+          this.showAlert(message)
         }
       }
     }
+  }
+
+  private async showAlert(message: string) {
+    if (this.authenticationAlert !== undefined) {
+      return
+    }
+
+    this.authenticationAlert = await this.alertController.create({
+      message,
+      buttons: [
+        {
+          text: this.translateService.instant('general.ok'),
+          handler: () => {
+            this.authenticationAlert?.dismiss()
+            this.authenticationAlert = undefined
+          },
+        },
+      ],
+      backdropDismiss: false,
+    })
+    await this.authenticationAlert?.present()
   }
 
   private needsAuthentication(): boolean {

--- a/src/app/select-trajectory/trajectory-card/trajectory-card-popover/trajectory-card-popover.page.ts
+++ b/src/app/select-trajectory/trajectory-card/trajectory-card-popover/trajectory-card-popover.page.ts
@@ -5,8 +5,6 @@ import {
   ModalController,
   PopoverController,
   ToastController,
-  Platform,
-  ActionSheetController,
 } from '@ionic/angular'
 import { TranslateService } from '@ngx-translate/core'
 import { TrajectoryMeta, TrajectoryType } from 'src/app/model/trajectory'
@@ -26,13 +24,11 @@ export class TrajectoryCardPopoverPage implements OnInit {
   @Input() trajectory: TrajectoryMeta
 
   constructor(
-    private platform: Platform,
     private modalController: ModalController,
     private popoverController: PopoverController,
     private alertController: AlertController,
     private loadingController: LoadingController,
     private toastController: ToastController,
-    private actionSheetController: ActionSheetController,
     private locationService: LocationService,
     private trajectoryImportExportService: TrajectoryImportExportService,
     private translateService: TranslateService,
@@ -49,18 +45,14 @@ export class TrajectoryCardPopoverPage implements OnInit {
     e.stopPropagation()
     this.popoverController.dismiss()
 
-    if (this.platform.is('android')) {
-      await this.presentExportActionSheet()
-    } else {
-      await this.showLoadingDialog(
-        this.translateService.instant('trajectory.export.loadingDialogMessage')
-      )
-      await this.trajectoryImportExportService
-        .exportTrajectoryViaShareDialog(this.trajectory)
-        .then(async (result) => {
-          await this.handleExportResult(result)
-        })
-    }
+    await this.showLoadingDialog(
+      this.translateService.instant('trajectory.export.loadingDialogMessage')
+    )
+    await this.trajectoryImportExportService
+      .exportTrajectoryViaShareDialog(this.trajectory)
+      .then(async (result) => {
+        await this.handleExportResult(result)
+      })
   }
 
   async deleteTrajectory(e: Event) {
@@ -114,52 +106,6 @@ export class TrajectoryCardPopoverPage implements OnInit {
       ],
     })
     await alert.present()
-  }
-
-  private async presentExportActionSheet() {
-    const actionSheet = await this.actionSheetController.create({
-      header: this.translateService.instant('trajectory.export.alertHeader'),
-      buttons: [
-        {
-          text: this.translateService.instant('trajectory.export.saveMessage'),
-          icon: 'save-outline',
-          handler: async () => {
-            await this.showLoadingDialog(
-              this.translateService.instant(
-                'trajectory.export.loadingDialogMessage'
-              )
-            )
-            await this.trajectoryImportExportService
-              .exportTrajectoryToDownloads(this.trajectory)
-              .then(async (result) => {
-                await this.handleExportResult(result)
-              })
-          },
-        },
-        {
-          text: this.translateService.instant('general.share'),
-          icon: 'share-social-outline',
-          handler: async () => {
-            await this.showLoadingDialog(
-              this.translateService.instant(
-                'trajectory.export.loadingDialogMessage'
-              )
-            )
-            await this.trajectoryImportExportService
-              .exportTrajectoryViaShareDialog(this.trajectory)
-              .then(async (result) => {
-                await this.handleExportResult(result)
-              })
-          },
-        },
-        {
-          text: this.translateService.instant('general.cancel'),
-          icon: 'close',
-          role: 'cancel',
-        },
-      ],
-    })
-    await actionSheet.present()
   }
 
   private async handleExportResult(result: TrajectoryExportResult) {

--- a/src/app/shared-services/diary/diary.service.ts
+++ b/src/app/shared-services/diary/diary.service.ts
@@ -5,7 +5,7 @@ import { SqliteService } from '../db/sqlite.service'
 import { TranslateService } from '@ngx-translate/core'
 import JSZip from 'jszip'
 import { LogfileService } from '../logfile/logfile.service'
-import { Directory, Filesystem } from '@capacitor/filesystem'
+import { Directory, Encoding, Filesystem } from '@capacitor/filesystem'
 import { Share } from '@capacitor/share'
 
 @Injectable({
@@ -68,7 +68,8 @@ export class DiaryService {
     const fileResult = await Filesystem.writeFile({
       data,
       path: `SIMPORT_export_${timestamp}.zip`,
-      directory: Directory.Documents,
+      directory: Directory.Cache, // write in cache as temp folder
+      encoding: Encoding.UTF8,
     })
 
     Share.share({

--- a/src/app/shared-services/trajectory/trajectory-import-export.service.ts
+++ b/src/app/shared-services/trajectory/trajectory-import-export.service.ts
@@ -6,7 +6,6 @@ import {
 } from '../../model/trajectory'
 import { TrajectoryService } from '../../shared-services/trajectory/trajectory.service'
 import { v4 as uuid } from 'uuid'
-import { Platform } from '@ionic/angular'
 import { HttpClient } from '@angular/common/http'
 import { SqliteService } from '../db/sqlite.service'
 
@@ -44,7 +43,6 @@ export class TrajectoryImportExportService extends TrajectoryService {
   constructor(
     http: HttpClient,
     db: SqliteService,
-    private platform: Platform,
     private translateService: TranslateService
   ) {
     super(http, db)
@@ -181,10 +179,6 @@ export class TrajectoryImportExportService extends TrajectoryService {
         encoding: Encoding.UTF8,
       })
 
-      if (this.platform.is('android')) {
-        // await Share.requestPermissions()
-      }
-
       // share file
       await Share.share({
         title: this.translateService.instant('trajectory.export.alertHeader'),
@@ -206,36 +200,6 @@ export class TrajectoryImportExportService extends TrajectoryService {
         errorMessage: `${this.translateService.instant(
           'trajectory.export.errorMessage'
         )}: ${error.errorMessage ? error.errorMessage : error}`,
-      }
-    }
-  }
-
-  /**
-   * This is android-only.
-   *
-   * @param t trajectory to export
-   */
-  async exportTrajectoryToDownloads(
-    trajectoryMeta: TrajectoryMeta
-  ): Promise<TrajectoryExportResult> {
-    const trajectoryFile = await this.createTrajectoryExportFileFromMeta(
-      trajectoryMeta,
-      false
-    )
-    try {
-      await Filesystem.writeFile({
-        path: `Download/${trajectoryFile.filename}.json`,
-        data: trajectoryFile.trajectory,
-        directory: Directory.ExternalStorage,
-        encoding: Encoding.UTF8,
-      })
-      return { success: true, errorMessage: null }
-    } catch (e) {
-      return {
-        success: false,
-        errorMessage: this.translateService.instant(
-          'trajectory.export.errorMessage'
-        ),
       }
     }
   }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -12,6 +12,7 @@
     "yes": "Ja",
     "save": "Speichern",
     "discard": "Verwerfen",
+    "ok": "OK",
     "exampleTrajectoryName": "Münster"
   },
   "diary": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -12,6 +12,7 @@
     "yes": "Yes",
     "save": "Save",
     "discard": "Discard",
+    "ok": "OK",
     "exampleTrajectoryName": "Münster"
   },
   "diary": {


### PR DESCRIPTION
Closes #326

- added interval of 60 seconds, where users don't need to reauthenticate
- removed 'save to downloads' export-option for trajectories (this was android only), because this is not working anymore on Android 11 and newer. We're using the usual share-plugin exclusively instead (which was an export-option before as well)